### PR TITLE
Fix issue #2 and upgrade Jetty to the most recent release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>9.0.0.M4</version>
+            <version>9.4.7.v20170914</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.6.v20170531</version>
+                <version>9.4.7.v20170914</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.23.2</version>
+            <version>2.26</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -76,9 +76,14 @@
             <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-bundle</artifactId>
-            <version>1.19</version>
+            <groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-common</artifactId>
+			<version>2.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+			<version>2.26</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/opencds/cqf/cql/execution/ExecutorLibraryLoader.java
+++ b/src/main/java/org/opencds/cqf/cql/execution/ExecutorLibraryLoader.java
@@ -1,15 +1,23 @@
 package org.opencds.cqf.cql.execution;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.cqframework.cql.cql2elm.*;
 import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.execution.ObjectFactory;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.cql_annotations.r1.Annotation;
 import org.opencds.cqf.cql.data.fhir.BaseFhirDataProvider;
 
+import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.PropertyException;
+import javax.xml.bind.Unmarshaller;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,35 +40,50 @@ public class ExecutorLibraryLoader implements LibraryLoader {
 
     @Override
     public Library load(VersionedIdentifier versionedIdentifier) {
-        Library library = libraries.get(versionedIdentifier.getId());
+		Library library = libraries.get(versionedIdentifier.getId());
 
-        // TODO - Figure this out
-//        if (library == null) {
-//            org.hl7.elm.r1.VersionedIdentifier elmIdentifier =
-//                    new org.hl7.elm.r1.VersionedIdentifier()
-//                            .withId(versionedIdentifier.getId())
-//                            .withVersion(versionedIdentifier.getVersion());
-//
-//            List<CqlTranslatorException> errors = new ArrayList<>();
-//            org.cqframework.cql.cql2elm.model.TranslatedLibrary librarySource = libraryManager.resolveLibrary(elmIdentifier, errors);
-//
-//            if (errors.size() > 0) {
-//                throw new CqlTranslatorIncludeException(String.format("Errors occurred translating library %s, version %s.",
-//                        versionedIdentifier.getId(), versionedIdentifier.getVersion()), versionedIdentifier.getId(), versionedIdentifier.getVersion());
-//            }
-//
-//            try {
-//                InputStream xmlStream = new ByteArrayInputStream(CqlTranslator.fromStream(is == null ? new ByteArrayInputStream(new byte[]{}) : is, modelManager, libraryManager).convertToXml(librarySource).getBytes(StandardCharsets.UTF_8)));
-//                library = CqlLibraryReader.read(xmlStream);
-//            }
-//            catch (IOException | JAXBException e) {
-//                throw new CqlTranslatorIncludeException(String.format("Errors occurred translating library %s, version %s.",
-//                        versionedIdentifier.getId(), versionedIdentifier.getVersion()), versionedIdentifier.getId(), versionedIdentifier.getVersion(), e);
-//            }
-//
-//            libraries.put(versionedIdentifier.getId(), library);
-//        }
+		// TODO - Figure this out
+		if (library == null) {
+			org.hl7.elm.r1.VersionedIdentifier elmIdentifier = new org.hl7.elm.r1.VersionedIdentifier()
+					.withId(versionedIdentifier.getId()).withVersion(versionedIdentifier.getVersion());
+
+			List<CqlTranslatorException> errors = new ArrayList<>();
+			org.cqframework.cql.cql2elm.model.TranslatedLibrary librarySource = libraryManager
+					.resolveLibrary(elmIdentifier, errors);
+			if (errors.size() > 0) {
+				throw new CqlTranslatorIncludeException(
+						String.format("Errors occurred translating library %s, version %s.",
+								versionedIdentifier.getId(), versionedIdentifier.getVersion()),
+						versionedIdentifier.getId(), versionedIdentifier.getVersion());
+			}
+			String elmXml = toXML(librarySource.getLibrary());
+			try {
+				library = CqlLibraryReader.read(new ByteArrayInputStream(elmXml.getBytes(StandardCharsets.UTF_8)));
+			} catch (IOException | JAXBException e) {
+				throw new CqlTranslatorIncludeException(
+						String.format("Errors occurred translating library %s, version %s.",
+								versionedIdentifier.getId(), versionedIdentifier.getVersion()),
+						versionedIdentifier.getId(), versionedIdentifier.getVersion(), e);
+			}
+		}
 
         return library;
     }
+
+	private String toXML(org.hl7.elm.r1.Library library) {
+		String elmXml = "";
+		try {
+			StringWriter writer = new StringWriter();
+			JAXBContext jaxbContext = JAXBContext.newInstance(org.hl7.elm.r1.Library.class, Annotation.class);
+			Marshaller marshaller = jaxbContext.createMarshaller();
+			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+			marshaller.marshal(new org.hl7.elm.r1.ObjectFactory().createLibrary(library), writer);
+			elmXml =  writer.getBuffer().toString();
+		} 
+		catch (JAXBException e) {
+			throw new CqlTranslatorIncludeException(String.format("Errors occurred marshalling library %s, version %s to ELM xml.",
+                    library.getIdentifier().getId(), library.getIdentifier().getVersion()), library.getIdentifier().getId(), library.getIdentifier().getVersion(), e);
+		}
+		return elmXml;
+	}
 }


### PR DESCRIPTION
Here is possible fix for the include CQL library expression evaluation and upgrading Jetty to the most recent release so that it can be deployed on the official Jetty 9.4.7 docker image container